### PR TITLE
upload folder backslash fix

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -125,7 +125,7 @@ func newUploadRequest(cred *Credentials, paths []string) (*http.Request, error) 
 				return err
 			}
 
-			part, err := writer.CreateFormFile(p, p)
+			part, err := writer.CreateFormFile(strings.Replace(p, "\\", "/", -1), p)
 
 			if err != nil {
 				return err


### PR DESCRIPTION
(windows) fix to allow a folder to upload correctly (E.g neocities upload folder)
Old code did upload files inside the folder, but put them in the root direcory in neocities using
folder + \ +file name  in the filename(s)  (instead of creating the correct folder and file structure).
Replacing backslash to forward slash fixes this.